### PR TITLE
add CURRENT_PROJECT_VERSION to Release target to prevent ITMS-90056

### DIFF
--- a/Swime.xcodeproj/project.pbxproj
+++ b/Swime.xcodeproj/project.pbxproj
@@ -243,7 +243,7 @@
 		OBJ_98 /* ToSucceed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToSucceed.swift; sourceTree = "<group>"; };
 		"Quick::Quick::Product" /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Quick::QuickSpecBase::Product" /* QuickSpecBase.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = QuickSpecBase.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"Swime::Swime::Product" /* Swime.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Swime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		"Swime::Swime::Product" /* Swime.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Swime.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Swime::SwimeTests::Product" /* SwimeTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = SwimeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -439,7 +439,7 @@
 			path = ".build/checkouts/Nimble-7519179571779245347/Sources/Nimble";
 			sourceTree = SOURCE_ROOT;
 		};
-		OBJ_5 /*  */ = {
+		OBJ_5 = {
 			isa = PBXGroup;
 			children = (
 				OBJ_6 /* Package.swift */,
@@ -448,7 +448,6 @@
 				OBJ_14 /* Dependencies */,
 				OBJ_106 /* Products */,
 			);
-			name = "";
 			sourceTree = "<group>";
 		};
 		OBJ_50 /* Adapters */ = {
@@ -691,7 +690,7 @@
 			knownRegions = (
 				en,
 			);
-			mainGroup = OBJ_5 /*  */;
+			mainGroup = OBJ_5;
 			productRefGroup = OBJ_106 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1105,6 +1104,7 @@
 		OBJ_224 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
When importing using Carthage the SDK works fine during development but during distribution the App Store rejects the upload.
```
App Store Connect Operation Error
	ERROR ITMS-90056: "This bundle Payload/SomeApp.app/Frameworks/Swime.framework is invalid. The Info.plist file is missing the required key: CFBundleVersion."
```

Since Swime sets the bundle version to `$(CURRENT_PROJECT_VERSION)` I set the `CURRENT_PROJECT_VERSION` to be 1 during Release builds.

I've confirmed this resolves the issue but I'm not sure if this is the right approach.

I looked around at some other frameworks and it seems that many just set CURRENT_PROJECT_VERSION to 1 during Release 
https://github.com/Alamofire/Alamofire/blob/master/Alamofire.xcodeproj/project.pbxproj#L1808
https://github.com/PureLayout/PureLayout/blob/master/PureLayout/PureLayout.xcodeproj/project.pbxproj#L1553
