### PR TITLE
revert iOS target to 9.0

### DIFF
--- a/Swime.xcodeproj/project.pbxproj
+++ b/Swime.xcodeproj/project.pbxproj
@@ -1087,6 +1087,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Swime.xcodeproj/Swime_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";
@@ -1112,6 +1113,7 @@
 				);
 				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Swime.xcodeproj/Swime_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) $(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
 				OTHER_CFLAGS = "$(inherited)";
 				OTHER_LDFLAGS = "$(inherited)";


### PR DESCRIPTION
Reverting a change made in https://github.com/sendyhalim/Swime/pull/7/files/18b70a5724f1707f492c3f31b411af6cee5f6398#diff-f8852957662e81196d3f84eb2cc73713

I don't see any reason Swime would need iOS >=11.0

Allows for Swime to be used in applications that may target iOS <11.0