### PR TITLE
Fix deprecated code

### DIFF
--- a/Sources/Swime.swift
+++ b/Sources/Swime.swift
@@ -38,7 +38,7 @@ public struct Swime {
   }
 
   public init(bytes: [UInt8]) {
-    self.init(data: Data(bytes: bytes))
+    self.init(data: Data(bytes))
   }
 
   ///  Read bytes from file data


### PR DESCRIPTION
Fix `'init(bytes:)' is deprecated: use `init(_:)` instead`