### PR TITLE
Update Package.swift to specify platform targets in line with pod spec

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,8 +1,12 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
   name: "Swime",
+  platforms: [
+    .iOS(.v9),
+    .macOS(.v10_10)
+  ],
   products: [
     .library(name: "Swime", targets: ["Swime"])
   ],


### PR DESCRIPTION
As the title says, this adds the platforms section to the SPM definition. I've made them match the same targets that are in the pod spec.