### PR TITLE
Fix bug in min byte count for `eot` file types.

### DIFF
--- a/Sources/MimeType.swift
+++ b/Sources/MimeType.swift
@@ -572,7 +572,7 @@ public struct MimeType {
       mime: "application/octet-stream",
       ext: "eot",
       type: .eot,
-      bytesCount: 11,
+      bytesCount: 36,
       matches: { bytes, _ in
         return (bytes[34...35] == [0x4C, 0x50]) &&
           ((bytes[8...10] == [0x00, 0x00, 0x01]) || (bytes[8...10] == [0x01, 0x00, 0x02]) || (bytes[8...10] == [0x02, 0x00, 0x02]))


### PR DESCRIPTION
The `.eot` type requires `bytes[34...35] == [0x4C, 0x50]` however the `bytesCount` value was only set to 11. This lead to a out of range crash if the input data was less than this. In our testing the utf-8 string `editing ...` created this crash.

The fix is to increase the `bytesCount` to 36