### PR TITLE
Add support for heic ext

### DIFF
--- a/Sources/MimeType.swift
+++ b/Sources/MimeType.swift
@@ -67,6 +67,7 @@ public enum FileType {
   case xz
   case z
   case zip
+  case heic
 }
 
 public struct MimeType {
@@ -746,6 +747,15 @@ public struct MimeType {
       matches: { bytes, _ in
         return bytes[0...13] == [0x06, 0x0E, 0x2B, 0x34, 0x02, 0x05, 0x01, 0x01, 0x0D, 0x01, 0x02, 0x01, 0x01, 0x02 ]
       }
+    ),
+    MimeType(
+        mime: "application/heic",
+        ext: "heic",
+        type: .heic,
+        bytesCount: 4,
+        matches: { bytes, _ in
+            return bytes[8...11] == [0x68, 0x65, 0x69, 0x63] || bytes[8...11] == [0x68, 0x65, 0x69, 0x78]
+        }
     )
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,7 @@ public enum MimeTypeExtension {
   case xz
   case z
   case zip
+  case heic
 }
 ```
 


### PR DESCRIPTION
What does this implement/fix? Explain your changes.
---------------------------------------------------
Add support for `heic` extension. iOS 11's new image format.

Does this close any currently open issues?
------------------------------------------
Closes #4 

Any relevant logs, error output, etc?
-------------------------------------
No

Any other comments?
-------------------
Ported from [this](https://github.com/sindresorhus/file-type/blob/4ce68386d3c16dce80bc6cd407c94e82db483182/core.js#L481)

Where has this been tested?
---------------------------
**Devices/Simulators:** Device

**iOS Version:** 15.1

**Swift Version:** Swift 5